### PR TITLE
Updates for base test and debugging capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/testbox
+Solution.cfc
+SolutionTest.cfc

--- a/CodewarsBaseSpec.cfc
+++ b/CodewarsBaseSpec.cfc
@@ -1,0 +1,14 @@
+component extends="testbox.system.BaseSpec" {
+     /**
+     * @aroundEach
+     */
+	 function captureOutput( spec, suite ){
+		savecontent variable="local.out" {
+    		arguments.spec.body();
+		}
+		if( len( trim( local.out ) ) ) {
+			debug( local.out )
+		}
+ 	 }
+      
+}

--- a/CodewarsBaseSpec.cfc
+++ b/CodewarsBaseSpec.cfc
@@ -3,12 +3,21 @@ component extends="testbox.system.BaseSpec" {
      * @aroundEach
      */
 	 function captureOutput( spec, suite ){
-		savecontent variable="local.out" {
-    		arguments.spec.body();
-		}
-		if( len( trim( local.out ) ) ) {
-			debug( local.out )
-		}
+         var out = '';
+            savecontent variable="local.out" {
+                try{
+                    arguments.spec.body();
+                } catch( any e ) {
+                    var thisFailure = e;
+                }
+            }
+            // make sure we debug any output, even on failure
+            if( len( trim( local.out ) ) ) {
+                debug( local.out )
+            }
+            if( !isNull( thisFailure ) ) {
+                throw( thisFailure );
+            }
  	 }
-      
+
 }

--- a/CodewarsReporter.cfc
+++ b/CodewarsReporter.cfc
@@ -23,9 +23,11 @@ component {
 				}
 			}
 
+			var debugMap = prepareDebugBuffer( thisBundle.debugBuffer );
+
 			// Generate reports for each suite
 			for ( var suiteStats in thisBundle.suiteStats ) {
-				genSuiteReport( suiteStats = suiteStats, bundleStats = thisBundle, print = print );
+				genSuiteReport( suiteStats = suiteStats, bundleStats = thisBundle, print = print, debugMap = debugMap );
 			}
 		}
 	}
@@ -36,16 +38,24 @@ component {
 	 * @bundleStats Bundle stats
 	 * @print The print Buffer
 	 */
-	function genSuiteReport( required suiteStats, required bundleStats, required print ){
+	function genSuiteReport( required suiteStats, required bundleStats, required print, debugMap={}, labelPrefix='' ){
+		labelPrefix &= '/' & arguments.suiteStats.name;
 		print.line( prependLF( "<DESCRIBE::>#arguments.suiteStats.name#" ) );
 
 		for ( local.thisSpec in arguments.suiteStats.specStats ) {
+			var thisSpecLabel = labelPrefix & '/' & local.thisSpec.name;
 			print.line( prependLF( "<IT::>#local.thisSpec.name#" ) );
+
+			if( debugMap.keyExists( thisSpecLabel ) ) {
+				print.line( debugMap[ thisSpecLabel ] )
+			}
 
 			if ( local.thisSpec.status == "passed" ) {
 				print.line( prependLF( "<PASSED::>Test Passed" ) );
 			} else if ( local.thisSpec.status == "failed" ) {
 				print.line( prependLF( "<FAILED::>#escapeLF( local.thisSpec.failMessage )#" ) );
+			} else if ( local.thisSpec.status == "skipped" ) {
+				print.line( prependLF( "<LOG::>Skipped" ) );				
 			} else if ( local.thisSpec.status == "error" ) {
 				print.line( prependLF( "<ERROR::>#escapeLF( local.thisSpec.error.message )#" ) );
 
@@ -80,7 +90,7 @@ component {
 		// Handle nested Suites
 		if ( arguments.suiteStats.suiteStats.len() ) {
 			for ( local.nestedSuite in arguments.suiteStats.suiteStats ) {
-				genSuiteReport( local.nestedSuite, arguments.bundleStats, print )
+				genSuiteReport( local.nestedSuite, arguments.bundleStats, print, debugMap, labelPrefix )
 			}
 		}
 
@@ -93,6 +103,16 @@ component {
 
 	private function prependLF( required text ){
 		return "#chr( 10 )##text#";
+	}
+
+	// Transofrm array of messages to struct keyed on message label containing an array of 
+	private function prepareDebugBuffer( array debugBuffer ) {
+		return debugBuffer.reduce( ( debugMap={}, d )=> {
+			debugMap[ d.label ] = debugMap[ d.label ] ?: '';
+			debugMap[ d.label ] &= prependLF( isSimpleValue( d.data ) ? d.data : serialize( d.data ) );
+			return debugMap;
+		} ) ?: {};
+
 	}
 
 }

--- a/CodewarsReporter.cfc
+++ b/CodewarsReporter.cfc
@@ -55,7 +55,8 @@ component {
 			} else if ( local.thisSpec.status == "failed" ) {
 				print.line( prependLF( "<FAILED::>#escapeLF( local.thisSpec.failMessage )#" ) );
 			} else if ( local.thisSpec.status == "skipped" ) {
-				print.line( prependLF( "<LOG::>Skipped" ) );				
+				print.line( prependLF( "<LOG::>Skipped" ) );
+				print.line( prependLF( "<ERROR::>Test skipped" ) );
 			} else if ( local.thisSpec.status == "error" ) {
 				print.line( prependLF( "<ERROR::>#escapeLF( local.thisSpec.error.message )#" ) );
 

--- a/CodewarsReporter.cfc
+++ b/CodewarsReporter.cfc
@@ -55,8 +55,7 @@ component {
 			} else if ( local.thisSpec.status == "failed" ) {
 				print.line( prependLF( "<FAILED::>#escapeLF( local.thisSpec.failMessage )#" ) );
 			} else if ( local.thisSpec.status == "skipped" ) {
-				print.line( prependLF( "<LOG::>Skipped" ) );
-				print.line( prependLF( "<ERROR::>Test skipped" ) );
+				print.line( prependLF( "<FAILED::>Test Skipped" ) );
 			} else if ( local.thisSpec.status == "error" ) {
 				print.line( prependLF( "<ERROR::>#escapeLF( local.thisSpec.error.message )#" ) );
 

--- a/TestRunner.cfc
+++ b/TestRunner.cfc
@@ -7,23 +7,23 @@ component {
 
 	function run(){
 		// Bootstrap TestBox framework
-		filesystemUtil.createMapping( "/testbox", getCWD() & "/testbox" );
+		filesystemUtil.createMapping( "/testbox", resolvepath( "testbox" ) );
 
 		// Create TestBox and run the tests
-		testData = new testbox.system.TestBox()
+		testData = new testbox.system.TestBox( options={ coverage : { enabled : false } } )
 			.runRaw(
 				directory = {
 					// Find all CFCs in this directory that ends with Test.
 					mapping : filesystemUtil.makePathRelative( getCWD() ),
 					recurse : false,
 					filter = function( path ){
-						return path.reFindNoCase( "Test.cfc$" );
+						return path.reFindNoCase( "Test\.cfc$" );
 					}
 				}
 			)
-			.getMemento();
+			.getMemento( includeDebugBuffer=true );
 
-		createObject( "CodewarsReporter" ).render( print, testData );
+		new CodewarsReporter().render( print, testData );
 
 		// Flush the buffer
 		print.toConsole();

--- a/box.json
+++ b/box.json
@@ -1,0 +1,15 @@
+{
+    "name":"testbox-codewars",
+    "version":"1.0.0",
+    "slug":"testbox-codewars",
+    "createPackgeDirectory":false,
+    "shortDescription":"Custom reporter and runner for TestBox",
+    "type":"projects",
+    "dependencies":{
+        "testbox":"^3.1.0+339"
+    },
+    "installPaths":{
+        "testbox":"testbox/"
+    },
+    "scripts":{}
+}

--- a/box.json
+++ b/box.json
@@ -2,7 +2,7 @@
     "name":"testbox-codewars",
     "version":"1.0.0",
     "slug":"testbox-codewars",
-    "createPackgeDirectory":false,
+    "createPackageDirectory":false,
     "shortDescription":"Custom reporter and runner for TestBox",
     "type":"projects",
     "dependencies":{


### PR DESCRIPTION
This change captures debug stream data from TestBox and logs it with the corresponding data.  Also all test cases that extend `CodewarsBaseSpec` will automatically any output from the solution created via
```js
writeOutput( 'test' )
echo( 'test' & chr(10) )
dump( var=['complex','data'], format='plain' )
```
and convert it to text for the log.

I recommend we edit existing CFML katas to extend this base test case instead of `testbox.system.baseSpec` and also modify the template test case to show this by default as well.